### PR TITLE
Add WooCommerce export integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "express": "^4.18.2",
-        "multer": "^1.4.5-lts.1"
+        "multer": "^1.4.5-lts.1",
+        "woocommerce-rest-api": "^1.0.1"
       }
     },
     "node_modules/accepts": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "type": "commonjs",
   "dependencies": {
     "express": "^4.18.2",
-    "multer": "^1.4.5-lts.1"
+    "multer": "^1.4.5-lts.1",
+    "woocommerce-rest-api": "^1.0.1"
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -56,6 +56,7 @@
               </svg>
               Eksporter CSV
             </button>
+            <button class="btn ml-2" id="exportApiBtn">Eksportér til webshop</button>
           </div>
           <div id="exportStatus" class="my-4"></div>
         </div>
@@ -105,6 +106,41 @@
         <div id="historySection" class="mt-8 hidden">
           <h2 class="text-xl font-semibold mb-2">Historik</h2>
           <div id="historyList" class="space-y-2"></div>
+        </div>
+
+        <div id="settingsSection" class="mt-8">
+          <h2 class="text-xl font-semibold mb-2">WooCommerce indstillinger</h2>
+          <div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+            <div>
+              <label class="rate-label" for="storeUrlInput">Store URL:</label>
+              <input type="text" class="rate-input" id="storeUrlInput" placeholder="https://example.com">
+            </div>
+            <div>
+              <label class="rate-label" for="consumerKeyInput">Consumer Key:</label>
+              <input type="text" class="rate-input" id="consumerKeyInput">
+            </div>
+            <div>
+              <label class="rate-label" for="consumerSecretInput">Consumer Secret:</label>
+              <input type="text" class="rate-input" id="consumerSecretInput">
+            </div>
+            <div>
+              <label class="rate-label" for="apiVersionInput">API Version:</label>
+              <input type="text" class="rate-input" id="apiVersionInput" value="wc/v3">
+            </div>
+            <div>
+              <label class="inline-flex items-center mt-6">
+                <input type="checkbox" id="ignoreSslInput" class="mr-2">Ignorer SSL fejl
+              </label>
+            </div>
+            <div>
+              <label class="rate-label" for="visibilityInput">Standard synlighed:</label>
+              <input type="text" class="rate-input" id="visibilityInput" value="visible">
+            </div>
+          </div>
+          <div class="mt-4">
+            <button class="btn" id="testConnectionBtn">Test forbindelse</button>
+            <span id="connectionStatus" class="ml-4"></span>
+          </div>
         </div>
       </div>
     </div>

--- a/server.js
+++ b/server.js
@@ -2,9 +2,23 @@ const express = require('express');
 const fs = require('fs');
 const path = require('path');
 const multer = require('multer');
+const https = require('https');
+const WooCommerceRestApi = require('woocommerce-rest-api').default;
 
 const app = express();
 const PORT = process.env.PORT || 3500;
+
+const createApi = ({ url, key, secret, version = 'wc/v3', ignoreSsl }) => {
+  return new WooCommerceRestApi({
+    url,
+    consumerKey: key,
+    consumerSecret: secret,
+    version,
+    axiosConfig: {
+      httpsAgent: new https.Agent({ rejectUnauthorized: !ignoreSsl })
+    }
+  });
+};
 
 // Directories
 const PUBLIC_DIR = path.join(__dirname, 'public');
@@ -16,6 +30,7 @@ if (!fs.existsSync(HISTORY_JSON)) fs.writeFileSync(HISTORY_JSON, '[]', 'utf8');
 
 app.use(express.static(PUBLIC_DIR));
 app.use('/history', express.static(HISTORY_DIR));
+app.use(express.json({ limit: '5mb' }));
 
 const storage = multer.diskStorage({
   destination: (req, file, cb) => cb(null, HISTORY_DIR),
@@ -49,6 +64,37 @@ app.post('/api/history', upload.single('file'), (req, res) => {
   entries.unshift(entry);
   fs.writeFileSync(HISTORY_JSON, JSON.stringify(entries, null, 2));
   res.json({ success: true, entry });
+});
+
+app.post('/api/test-woocommerce', async (req, res) => {
+  try {
+    const api = createApi(req.body);
+    await api.get('products', { per_page: 1 });
+    res.json({ success: true });
+  } catch (e) {
+    res.status(400).json({ success: false, error: e.message });
+  }
+});
+
+app.post('/api/export-woocommerce', async (req, res) => {
+  const { categories = [], products = [], visibility } = req.body;
+  try {
+    const api = createApi(req.body);
+    let catCount = 0, prodCount = 0;
+    for (const cat of categories) {
+      await api.post('products/categories', cat);
+      catCount++;
+    }
+    for (const p of products) {
+      const prod = { ...p };
+      if (visibility) prod.catalog_visibility = visibility;
+      await api.post('products', prod);
+      prodCount++;
+    }
+    res.json({ success: true, categories: catCount, products: prodCount });
+  } catch (e) {
+    res.status(400).json({ success: false, error: e.message });
+  }
 });
 
 app.listen(PORT, () => console.log(`Server running on http://localhost:${PORT}`));


### PR DESCRIPTION
## Summary
- allow configuring WooCommerce credentials in the UI
- add Test connection and Export to webshop actions
- implement API endpoints for WooCommerce integration
- add woocommerce-rest-api dependency

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b5935ac808333aa6e6db4a655baa1