### PR TITLE
Add dashboard for managing WooCommerce shops

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ En webbaseret værktøj til at behandle og eksportere WooCommerce produktdata fr
 1. Kør `npm install` (ingen afhængigheder installeres offline)
 2. Start serveren med `node server.js`
 3. Åbn `http://localhost:3000` i din browser
-4. Upload ZIP-filer, vælg data og eksporter
+4. Gå til `dashboard.html` for at administrere dine WooCommerce shops
+5. Upload ZIP-filer, vælg data og eksporter
 
 ## Udvikling
 

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="da">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>WooCommerce Advanced Exporter - Dashboard</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <style>
+    *{box-sizing:border-box;}body{min-height:100vh;margin:0;padding:20px;background:linear-gradient(135deg,#667eea42,#764ba262);color:#334155;font-family:'Inter',sans-serif;line-height:1.6;}
+    .container{max-width:1200px;margin:0 auto;background:rgba(255,255,255,.96);border-radius:16px;box-shadow:0 25px 50px rgba(0,0,0,.15);overflow:hidden;}
+    .header{background:linear-gradient(135deg,#667eea,#764ba2);color:white;padding:2rem;text-align:center;}
+    .header h1{font-size:2.5rem;font-weight:700;margin:0 0 .5rem;}
+    .header p{font-size:1.1rem;opacity:.9;margin:0;}
+    .main-content{padding:2rem;}
+    .section{background:white;border-radius:12px;padding:2rem;margin-bottom:2rem;box-shadow:0 4px 12px rgba(0,0,0,0.1);}
+    .section-title{font-size:1.5rem;font-weight:600;margin-bottom:1.5rem;color:#334155;display:flex;align-items:center;gap:.75rem;}
+    .section-icon{width:24px;height:24px;stroke:#667eea;}
+    .form-grid{display:grid;gap:1.5rem;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));}
+    .form-group{display:flex;flex-direction:column;gap:.5rem;}
+    .form-label{font-weight:500;color:#374151;font-size:.875rem;text-transform:uppercase;letter-spacing:.05em;}
+    .form-input{padding:.75rem 1rem;border:2px solid #e2e8f0;border-radius:8px;font-size:1rem;transition:all .2s;background:#fafbfc;}
+    .form-input:focus{outline:none;border-color:#667eea;box-shadow:0 0 0 3px rgba(102,126,234,0.1);background:white;}
+    .btn{display:inline-flex;align-items:center;justify-content:center;gap:.5rem;padding:.75rem 1.5rem;border:none;border-radius:8px;font-weight:600;cursor:pointer;transition:all .2s;text-decoration:none;}
+    .btn-primary{background:linear-gradient(135deg,#667eea,#764ba2);color:white;}
+    .btn-primary:hover:not(:disabled){transform:translateY(-2px);box-shadow:0 8px 25px rgba(102,126,234,0.4);}
+    .btn-secondary{background:#f8fafc;color:#64748b;border:2px solid #e2e8f0;}
+    .btn-secondary:hover{background:#f1f5f9;border-color:#cbd5e1;}
+    .btn-danger{background:#ef4444;color:white;}
+    .btn-danger:hover{background:#dc2626;}
+    .btn:disabled{opacity:.6;cursor:not-allowed;transform:none;}
+    .shop-card{border:2px solid #e2e8f0;border-radius:12px;padding:1.5rem;margin-bottom:1rem;transition:all .2s;}
+    .shop-card.connected{border-color:#10b981;background:#f0fdf4;}
+    .shop-card.disconnected{border-color:#ef4444;background:#fef2f2;}
+    .shop-card.testing{border-color:#f59e0b;background:#fffbeb;}
+    .shop-header{display:flex;justify-content:between;align-items:flex-start;margin-bottom:1rem;}
+    .shop-info{flex:1;}
+    .shop-name{font-size:1.25rem;font-weight:600;margin-bottom:.25rem;}
+    .shop-url{color:#64748b;font-size:.875rem;}
+    .shop-status{display:flex;align-items:center;gap:.5rem;margin-top:.75rem;}
+    .status-dot{width:8px;height:8px;border-radius:50%;}
+    .status-dot.connected{background:#10b981;}
+    .status-dot.disconnected{background:#ef4444;}
+    .status-dot.testing{background:#f59e0b;}
+    .shop-actions{display:flex;gap:.5rem;margin-top:1rem;}
+    .stats-grid{display:grid;gap:1.5rem;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));margin-bottom:2rem;}
+    .stat-card{background:linear-gradient(135deg,#f8fafc,#e2e8f0);border-radius:12px;padding:1.5rem;text-align:center;border-left:4px solid #667eea;}
+    .stat-number{font-size:2rem;font-weight:700;color:#334155;margin-bottom:.25rem;}
+    .stat-label{font-size:.875rem;color:#64748b;text-transform:uppercase;letter-spacing:.05em;}
+    .empty-state{text-align:center;padding:3rem 1rem;color:#64748b;}
+    .empty-icon{width:64px;height:64px;margin:0 auto 1rem;stroke:#cbd5e1;}
+    .status-message{padding:1rem;border-radius:8px;margin:1rem 0;}
+    .status-success{background:#dcfce7;color:#166534;border:1px solid #bbf7d0;}
+    .status-error{background:#fee2e2;color:#991b1b;border:1px solid #fecaca;}
+    .status-info{background:#dbeafe;color:#1e40af;border:1px solid #bfdbfe;}
+    .spinner{display:inline-block;width:16px;height:16px;border:2px solid currentColor;border-radius:50%;border-top-color:transparent;animation:spin 1s ease-in-out infinite;}
+    @keyframes spin{to{transform:rotate(360deg);}}
+    .hidden{display:none;}
+    .workflow-steps{display:flex;justify-content:center;margin:2rem 0;gap:1rem;}
+    .workflow-step{display:flex;flex-direction:column;align-items:center;gap:.5rem;padding:1rem;border-radius:8px;background:#f8fafc;min-width:120px;}
+    .workflow-step.active{background:#e0f2fe;border:2px solid #0369a1;}
+    .workflow-step.completed{background:#dcfce7;border:2px solid #16a34a;}
+    @media (max-width:768px){.form-grid{grid-template-columns:1fr;}.shop-header{flex-direction:column;gap:1rem;}.stats-grid{grid-template-columns:repeat(auto-fit,minmax(150px,1fr));}.workflow-steps{flex-direction:column;align-items:center;}}
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="header">
+      <h1>WooCommerce Advanced Exporter</h1>
+      <p>Administrer dine shops og behandl produktdata nemt og effektivt</p>
+    </div>
+    <div class="main-content">
+      <div class="workflow-steps">
+        <div class="workflow-step active" id="step1">
+          <svg class="section-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"/></svg>
+          <span>1. Opsæt Shops</span>
+        </div>
+        <div class="workflow-step" id="step2">
+          <svg class="section-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6H16a5 5 0 011 9.9M13 11l-3-3m0 0l-3 3m3-3v12"/></svg>
+          <span>2. Upload Data</span>
+        </div>
+        <div class="workflow-step" id="step3">
+          <svg class="section-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"/></svg>
+          <span>3. Eksporter</span>
+        </div>
+      </div>
+      <div class="stats-grid">
+        <div class="stat-card"><div class="stat-number" id="totalShops">0</div><div class="stat-label">Shops Oprettet</div></div>
+        <div class="stat-card"><div class="stat-number" id="connectedShops">0</div><div class="stat-label">Forbundet</div></div>
+        <div class="stat-card"><div class="stat-number" id="lastExport">Aldrig</div><div class="stat-label">Sidste Eksport</div></div>
+        <div class="stat-card"><div class="stat-number" id="totalExports">0</div><div class="stat-label">Total Eksporter</div></div>
+      </div>
+      <div class="section">
+        <h2 class="section-title"><svg class="section-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6"/></svg>Tilføj Ny Shop</h2>
+        <form id="shopForm">
+          <div class="form-grid">
+            <div class="form-group"><label class="form-label" for="shopName">Shop Navn</label><input type="text" id="shopName" class="form-input" placeholder="f.eks. Min WooCommerce Shop" required></div>
+            <div class="form-group"><label class="form-label" for="shopUrl">Shop URL</label><input type="url" id="shopUrl" class="form-input" placeholder="https://dinshop.dk" required></div>
+            <div class="form-group"><label class="form-label" for="consumerKey">Consumer Key</label><input type="text" id="consumerKey" class="form-input" placeholder="ck_xxxxxxxxxxxxx" required></div>
+            <div class="form-group"><label class="form-label" for="consumerSecret">Consumer Secret</label><input type="password" id="consumerSecret" class="form-input" placeholder="cs_xxxxxxxxxxxxx" required></div>
+          </div>
+          <div style="margin-top:1.5rem;display:flex;gap:1rem;">
+            <button type="button" id="testConnection" class="btn btn-secondary"><svg width="16" height="16" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>Test Forbindelse</button>
+            <button type="submit" id="addShop" class="btn btn-primary"><svg width="16" height="16" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6"/></svg>Gem Shop</button>
+          </div>
+        </form>
+        <div id="connectionStatus"></div>
+      </div>
+      <div class="section">
+        <h2 class="section-title"><svg class="section-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"/></svg>Dine Shops</h2>
+        <div id="shopsList">
+          <div class="empty-state"><svg class="empty-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"/></svg><h3>Ingen shops oprettet endnu</h3><p>Tilføj din første WooCommerce shop for at komme i gang</p></div>
+        </div>
+      </div>
+      <div class="section">
+        <h2 class="section-title"><svg class="section-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"/></svg>Handlinger</h2>
+        <div style="display:flex;gap:1rem;flex-wrap:wrap;">
+          <a href="index.html" class="btn btn-primary" id="startWorkflow"><svg width="16" height="16" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6H16a5 5 0 011 9.9M13 11l-3-3m0 0l-3 3m3-3v12"/></svg>Start Databehandling</a>
+          <button class="btn btn-secondary" id="testAllConnections"><svg width="16" height="16" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/></svg>Test Alle Forbindelser</button>
+          <button class="btn btn-secondary" id="exportSettings"><svg width="16" height="16" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"/></svg>Eksporter Indstillinger</button>
+        </div>
+      </div>
+    </div>
+  </div>
+<script src="scripts/dashboard.js"></script>
+</body>
+</html>

--- a/public/scripts/dashboard.js
+++ b/public/scripts/dashboard.js
@@ -1,0 +1,245 @@
+// Dashboard script
+const state = {
+  stats: {
+    totalShops: 0,
+    connectedShops: 0,
+    lastExport: 'Aldrig',
+    totalExports: 0
+  }
+};
+
+const elements = {
+  shopForm: document.getElementById('shopForm'),
+  shopName: document.getElementById('shopName'),
+  shopUrl: document.getElementById('shopUrl'),
+  consumerKey: document.getElementById('consumerKey'),
+  consumerSecret: document.getElementById('consumerSecret'),
+  testConnection: document.getElementById('testConnection'),
+  addShop: document.getElementById('addShop'),
+  connectionStatus: document.getElementById('connectionStatus'),
+  shopsList: document.getElementById('shopsList'),
+  totalShops: document.getElementById('totalShops'),
+  connectedShops: document.getElementById('connectedShops'),
+  lastExport: document.getElementById('lastExport'),
+  totalExports: document.getElementById('totalExports'),
+  testAllConnections: document.getElementById('testAllConnections')
+};
+
+const showStatus = (msg, type='info', container=elements.connectionStatus) => {
+  container.innerHTML = `<div class="status-message status-${type}">${msg}</div>`;
+};
+
+const loadShops = () => {
+  try { return JSON.parse(localStorage.getItem('wooShops')) || []; } catch { return []; }
+};
+
+const saveShops = shops => localStorage.setItem('wooShops', JSON.stringify(shops));
+
+const generateId = () => Date.now().toString();
+
+const validateUrl = url => {
+  try { new URL(url); return true; } catch { return false; }
+};
+
+const testShopConnection = async shop => {
+  if(!validateUrl(shop.url)) throw new Error('Ugyldig URL format');
+  const cleanUrl = shop.url.replace(/\/+$/, '');
+  const auth = btoa(`${shop.key}:${shop.secret}`);
+  try {
+    const res = await fetch(`${cleanUrl}/wp-json/wc/v3/system_status`, {
+      headers:{ Authorization:`Basic ${auth}`, 'Content-Type':'application/json' },
+      method:'GET', mode:'cors'
+    });
+    if(!res.ok) throw new Error(`HTTP ${res.status}`);
+    return { success: true };
+  } catch (err) {
+    try {
+      const r = await fetch(`${cleanUrl}/wp-json/wc/v3/products?per_page=1`, {
+        headers:{ Authorization:`Basic ${auth}`, 'Content-Type':'application/json' },
+        method:'GET', mode:'cors'
+      });
+      if(r.ok) return { success: true };
+    } catch {}
+    throw new Error(err.message || 'Forbindelse fejlede');
+  }
+};
+
+const updateStats = () => {
+  const shops = loadShops();
+  state.stats.totalShops = shops.length;
+  state.stats.connectedShops = shops.filter(s=>s.status==='connected').length;
+  elements.totalShops.textContent = state.stats.totalShops;
+  elements.connectedShops.textContent = state.stats.connectedShops;
+  elements.lastExport.textContent = state.stats.lastExport;
+  elements.totalExports.textContent = state.stats.totalExports;
+  const step1 = document.getElementById('step1');
+  if(state.stats.connectedShops>0){
+    step1.classList.remove('active');
+    step1.classList.add('completed');
+    document.getElementById('step2').classList.add('active');
+  }
+};
+
+const renderShops = () => {
+  const shops = loadShops();
+  if(!shops.length){
+    elements.shopsList.innerHTML = `<div class="empty-state"><svg class="empty-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"/></svg><h3>Ingen shops oprettet endnu</h3><p>Tilføj din første WooCommerce shop for at komme i gang</p></div>`;
+    return;
+  }
+  const html = shops.map(s=>{
+    const cls = s.status||'disconnected';
+    const txt = { connected:'Forbundet',disconnected:'Ikke forbundet',testing:'Tester...' }[cls]||'Ukendt';
+    return `<div class="shop-card ${cls}" data-id="${s.id}">
+      <div class="shop-header"><div class="shop-info"><div class="shop-name">${s.name}</div><div class="shop-url">${s.url}</div><div class="shop-status"><div class="status-dot ${cls}"></div><span>${txt}</span></div></div></div>
+      <div class="shop-actions">
+        <button class="btn btn-secondary test-shop-btn" data-id="${s.id}">Test</button>
+        <button class="btn btn-secondary edit-shop-btn" data-id="${s.id}">Rediger</button>
+        <button class="btn btn-danger remove-shop-btn" data-id="${s.id}">Slet</button>
+      </div>
+    </div>`;
+  }).join('');
+  elements.shopsList.innerHTML = html;
+};
+
+const handleTestConnection = async () => {
+  const shop = {
+    name: elements.shopName.value.trim(),
+    url: elements.shopUrl.value.trim(),
+    key: elements.consumerKey.value.trim(),
+    secret: elements.consumerSecret.value.trim()
+  };
+  if(!shop.name || !shop.url || !shop.key || !shop.secret){
+    showStatus('Udfyld alle felter først','error');
+    return;
+  }
+  elements.testConnection.disabled = true;
+  elements.testConnection.innerHTML = '<div class="spinner"></div> Tester...';
+  showStatus('Tester forbindelse...','info');
+  try {
+    await testShopConnection(shop);
+    showStatus('✅ Forbindelse successfuld! Du kan nu gemme shoppen.','success');
+  } catch(err){
+    showStatus(`❌ Forbindelse fejlede: ${err.message}`,'error');
+  } finally {
+    elements.testConnection.disabled = false;
+    elements.testConnection.innerHTML = '<svg width="16" height="16" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/></svg> Test Forbindelse';
+  }
+};
+
+const handleAddShop = async e => {
+  e.preventDefault();
+  const shop = {
+    id: generateId(),
+    name: elements.shopName.value.trim(),
+    url: elements.shopUrl.value.trim(),
+    key: elements.consumerKey.value.trim(),
+    secret: elements.consumerSecret.value.trim(),
+    status: 'testing'
+  };
+  if(!shop.name || !shop.url || !shop.key || !shop.secret){
+    showStatus('Udfyld alle felter først','error');
+    return;
+  }
+  const shops = loadShops();
+  try {
+    await testShopConnection(shop);
+    shop.status = 'connected';
+    showStatus('Shop gemt og forbindelse virker','success');
+  } catch(err){
+    shop.status = 'disconnected';
+    showStatus('Shop gemt, men forbindelse fejlede','warning');
+  }
+  shops.push(shop);
+  saveShops(shops);
+  elements.shopForm.reset();
+  renderShops();
+  updateStats();
+};
+
+elements.shopsList.addEventListener('click', async e => {
+  const id = e.target.dataset.id;
+  if(e.target.classList.contains('remove-shop-btn')){
+    const shops = loadShops().filter(s=>s.id!==id);
+    saveShops(shops);
+    renderShops();
+    updateStats();
+  } else if(e.target.classList.contains('test-shop-btn')){
+    const shops = loadShops();
+    const shop = shops.find(s=>s.id===id);
+    if(!shop) return;
+    e.target.disabled = true;
+    const original = e.target.innerHTML;
+    e.target.innerHTML = '<div class="spinner"></div>';
+    shop.status = 'testing';
+    renderShops();
+    try {
+      await testShopConnection(shop);
+      shop.status = 'connected';
+    } catch { shop.status = 'disconnected'; }
+    saveShops(shops);
+    renderShops();
+    updateStats();
+    e.target.disabled = false;
+    e.target.innerHTML = original;
+  } else if(e.target.classList.contains('edit-shop-btn')){
+    const shop = loadShops().find(s=>s.id===id);
+    if(!shop) return;
+    elements.shopName.value = shop.name;
+    elements.shopUrl.value = shop.url;
+    elements.consumerKey.value = shop.key;
+    elements.consumerSecret.value = shop.secret;
+    elements.addShop.textContent = 'Opdater Shop';
+    elements.addShop.dataset.editId = id;
+  }
+});
+
+elements.testAllConnections.addEventListener('click', async () => {
+  const shops = loadShops();
+  if(!shops.length) return;
+  elements.testAllConnections.disabled = true;
+  elements.testAllConnections.innerHTML = '<div class="spinner"></div> Tester...';
+  for(const shop of shops){
+    shop.status = 'testing';
+    renderShops();
+    try {
+      await testShopConnection(shop);
+      shop.status = 'connected';
+    } catch { shop.status = 'disconnected'; }
+  }
+  saveShops(shops);
+  renderShops();
+  updateStats();
+  elements.testAllConnections.disabled = false;
+  elements.testAllConnections.innerHTML = 'Test Alle Forbindelser';
+});
+
+elements.shopForm.addEventListener('submit', e => {
+  if(elements.addShop.dataset.editId){
+    const shops = loadShops();
+    const shop = shops.find(s=>s.id===elements.addShop.dataset.editId);
+    if(shop){
+      shop.name = elements.shopName.value.trim();
+      shop.url = elements.shopUrl.value.trim();
+      shop.key = elements.consumerKey.value.trim();
+      shop.secret = elements.consumerSecret.value.trim();
+      shop.status = 'disconnected';
+      saveShops(shops);
+      renderShops();
+      updateStats();
+      elements.addShop.textContent = 'Gem Shop';
+      delete elements.addShop.dataset.editId;
+      elements.shopForm.reset();
+      showStatus('Shop opdateret','success');
+    }
+    e.preventDefault();
+  } else {
+    handleAddShop(e);
+  }
+});
+
+elements.testConnection.addEventListener('click', handleTestConnection);
+
+document.addEventListener('DOMContentLoaded', () => {
+  renderShops();
+  updateStats();
+});


### PR DESCRIPTION
## Summary
- introduce a new `dashboard.html` page with steps, statistics and shop management
- implement `dashboard.js` to handle shop CRUD and connection testing
- document the dashboard page in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b7497dc308333bf008a2e8bcbe5db